### PR TITLE
Remove the redis and e2e-api-pod check

### DIFF
--- a/testing/fixtures/e2e_suite.go
+++ b/testing/fixtures/e2e_suite.go
@@ -117,15 +117,6 @@ func (s *E2ESuite) SetupSuite() {
 		CreateISBSvc().
 		WaitForISBSvcReady()
 	s.T().Log("ISB svc is ready")
-	err = PodPortForward(s.restConfig, Namespace, "e2e-api-pod", 8378, 8378, s.stopch)
-	s.CheckError(err)
-
-	// Create Redis resources used for sink data validation.
-	deleteCMD := fmt.Sprintf("kubectl delete -k ../../config/apps/redis -n %s --ignore-not-found=true", Namespace)
-	s.Given().When().Exec("sh", []string{"-c", deleteCMD}, OutputRegexp(""))
-	createCMD := fmt.Sprintf("kubectl apply -k ../../config/apps/redis -n %s", Namespace)
-	s.Given().When().Exec("sh", []string{"-c", createCMD}, OutputRegexp("service/redis created"))
-	s.T().Log("Redis resources are ready")
 }
 
 func (s *E2ESuite) TearDownSuite() {
@@ -143,9 +134,6 @@ func (s *E2ESuite) TearDownSuite() {
 		Expect().
 		ISBSvcDeleted(1 * time.Minute)
 	s.T().Log("ISB svc is deleted")
-	deleteCMD := fmt.Sprintf("kubectl delete -k ../../config/apps/redis -n %s --ignore-not-found=true", Namespace)
-	s.Given().When().Exec("sh", []string{"-c", deleteCMD}, OutputRegexp(`service "redis" deleted`))
-	s.T().Log("Redis resources are deleted")
 	close(s.stopch)
 }
 


### PR DESCRIPTION
As this is a generic library, so it should not depend of any requirement specific deployment. User can use the SetupTest() method to do these operation. So

- Remove the deployment of Redis
- Remove the check for e2e-api-pod

